### PR TITLE
Potential fix for shields and spears

### DIFF
--- a/src/main/java/net/snackbag/tt20/mixin/item/ItemMixin.java
+++ b/src/main/java/net/snackbag/tt20/mixin/item/ItemMixin.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(Item.class)
 public abstract class ItemMixin {
-    @ModifyReturnValue(method = "getMaxUseTime", at = @At("RETURN"))
+    @ModifyReturnValue(method = "getMaxUseTime", at = @At(value = "RETURN", ordinal = 0))
     private int onGetMaxUseTime(int original) {
         if (!TT20.config.enabled() || !TT20.config.eatingAcceleration() || original == 0) return original;
         return TPSUtil.tt20(original, true);


### PR DESCRIPTION
Changes the getMaxUseTime Item Mixin to exclude shields and spears.
This should fix the occasional damage applying through shields and spears acting weird.
Most of my testing was on 1.21.9-1.21.11, but this change should work on older versions that have the shield bug, and not affect those that don't (I did a quick code check for 1.19.2+).

Alternatively, I believe adding `|| original == 72000` to the if statement would also work.

Resolves #62 and resolves #42 